### PR TITLE
Feat/delete beacons implementation and small UI fixes

### DIFF
--- a/client/src/components/atoms/toast.tsx
+++ b/client/src/components/atoms/toast.tsx
@@ -28,7 +28,7 @@ const toastVariants = cva(
       variant: {
         default: "border bg-background",
         destructive:
-          "destructive group border-destructive bg-destructive text-destructive-foreground",
+          "destructive group border-red-600 bg-red-600 text-white",
         success: "border-primary bg-primary text-primary-foreground",
       },
     },

--- a/client/src/components/organisms/beacons/detailed-beacon.tsx
+++ b/client/src/components/organisms/beacons/detailed-beacon.tsx
@@ -13,7 +13,7 @@ import { useUser } from "@clerk/nextjs";
 import { useDeleteBeaconMutation, useGetUserByIdQuery } from "@/redux/api";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { toast } from "react-toastify";
+import { useToast } from "@/components/atoms/use-toast";
 import { ClimbingBoxLoader } from "react-spinners";
 
 interface DetailedBeaconProps {
@@ -25,6 +25,7 @@ const DetailedBeacon = ({ beacon, category }: DetailedBeaconProps) => {
   const userId = beacon.userId;
   const router = useRouter();
   const [isDeleting, setIsDeleting] = useState(false);
+  const { toast } = useToast();
 
   const { user: clerkUser } = useUser();
   const { data: userData, isLoading } = useGetUserByIdQuery(userId || "", {
@@ -43,18 +44,30 @@ const DetailedBeacon = ({ beacon, category }: DetailedBeaconProps) => {
   const handleDeleteBeacon = async () => {
     if (!beacon.BeaconId) {
       console.error("Cannot delete: Beacon ID is undefined");
-      toast.error("Cannot delete: Beacon ID is missing");
+      toast({
+        title: "Cannot Delete",
+        description: "Beacon ID is missing",
+        variant: "destructive",
+      });
       return;
     }
     
     try {
       setIsDeleting(true);
       await deleteBeacon(beacon.BeaconId).unwrap();
-      toast.success("Beacon deleted successfully");
+      toast({
+        title: "Beacon Deleted",
+        description: "Your beacon has been successfully deleted.",
+        variant: "success",
+      });
       router.push("/beacons/browse");
     } catch (error) {
       console.error("Failed to delete beacon:", error);
-      toast.error("Failed to delete beacon. Please try again.");
+      toast({
+        title: "Deletion Failed",
+        description: "Failed to delete beacon. Please try again.",
+        variant: "destructive",
+      });
     } finally {
       setIsDeleting(false);
     }

--- a/client/src/components/organisms/beacons/detailed-beacon.tsx
+++ b/client/src/components/organisms/beacons/detailed-beacon.tsx
@@ -41,6 +41,12 @@ const DetailedBeacon = ({ beacon, category }: DetailedBeaconProps) => {
   const isOwner = clerkUser?.id === userData?.clerk_user_id;
   
   const handleDeleteBeacon = async () => {
+    if (!beacon.BeaconId) {
+      console.error("Cannot delete: Beacon ID is undefined");
+      toast.error("Cannot delete: Beacon ID is missing");
+      return;
+    }
+    
     try {
       setIsDeleting(true);
       await deleteBeacon(beacon.BeaconId).unwrap();

--- a/client/src/components/organisms/beacons/detailed-beacon.tsx
+++ b/client/src/components/organisms/beacons/detailed-beacon.tsx
@@ -99,21 +99,23 @@ const DetailedBeacon = ({ beacon, category }: DetailedBeaconProps) => {
                   <span>Delete Beacon</span>
                 </Button>
               </AlertDialogTrigger>
-              <AlertDialogContent>
+              <AlertDialogContent className="bg-zinc-900 border-zinc-800 text-white">
                 <AlertDialogHeader>
-                  <AlertDialogTitle>Are you sure?</AlertDialogTitle>
-                  <AlertDialogDescription>
+                  <AlertDialogTitle className="text-white text-xl font-bold">Are you absolutely sure?</AlertDialogTitle>
+                  <AlertDialogDescription className="text-gray-300">
                     This action cannot be undone. This will permanently delete your beacon.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogFooter className="flex gap-2 mt-6">
+                  <AlertDialogCancel className="bg-zinc-800 hover:bg-zinc-700 text-white border-none">
+                    Cancel
+                  </AlertDialogCancel>
                   <AlertDialogAction
                     onClick={handleDeleteBeacon}
-                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    className="bg-red-600 hover:bg-red-700 text-white border-none"
                     disabled={isDeleting}
                   >
-                    {isDeleting ? 'Deleting...' : 'Delete'}
+                    {isDeleting ? 'Deleting...' : 'Delete Beacon'}
                   </AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>

--- a/client/src/components/organisms/beacons/detailed-beacon.tsx
+++ b/client/src/components/organisms/beacons/detailed-beacon.tsx
@@ -6,10 +6,14 @@ import BeaconInfoCard from "@/components/molecules/beacon-info-card";
 import ImagePreview from "@/components/molecules/image-preview";
 import UserCard from "@/components/molecules/user-card";
 import { Beacon, Category } from "@/types/beacon";
-import { ArrowLeft } from "lucide-react";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/atoms/alert-dialog";
+import { ArrowLeft, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useUser } from "@clerk/nextjs";
-import { useGetUserByIdQuery } from "@/redux/api";
+import { useDeleteBeaconMutation, useGetUserByIdQuery } from "@/redux/api";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "react-toastify";
 import { ClimbingBoxLoader } from "react-spinners";
 
 interface DetailedBeaconProps {
@@ -19,17 +23,36 @@ interface DetailedBeaconProps {
 
 const DetailedBeacon = ({ beacon, category }: DetailedBeaconProps) => {
   const userId = beacon.userId;
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const { user: clerkUser } = useUser();
   const { data: userData, isLoading } = useGetUserByIdQuery(userId || "", {
     skip: !userId,
   });
+  const [deleteBeacon] = useDeleteBeaconMutation();
 
   const location = [beacon.LocCity, beacon.LocRegion, beacon.LocCountry]
     .filter(Boolean)
     .join(", ");
 
   const avatarUrl = userData?.avatarUrl || clerkUser?.imageUrl || "/default-avatar.png";
+  
+  const isOwner = clerkUser?.id === userData?.clerk_user_id;
+  
+  const handleDeleteBeacon = async () => {
+    try {
+      setIsDeleting(true);
+      await deleteBeacon(beacon.BeaconId).unwrap();
+      toast.success("Beacon deleted successfully");
+      router.push("/beacons/browse");
+    } catch (error) {
+      console.error("Failed to delete beacon:", error);
+      toast.error("Failed to delete beacon. Please try again.");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
 
   if (isLoading) {
     return (
@@ -44,16 +67,53 @@ const DetailedBeacon = ({ beacon, category }: DetailedBeaconProps) => {
     <div className="flex flex-col gap-8 pt-4">
       {/* Back Button and Title Row */}
       <div className="flex flex-col gap-4">
-        <Button
-          variant="ghost"
-          asChild
-          className="self-start flex items-center gap-2 text-foreground/80 hover:text-foreground px-4 py-2"
-        >
-          <Link href="/beacons/browse">
-            <ArrowLeft className="h-5 w-5" />
-            <span className="text-base">Return to Browse</span>
-          </Link>
-        </Button>
+        <div className="flex justify-between items-center">
+          <Button
+            variant="ghost"
+            asChild
+            className="self-start flex items-center gap-2 text-foreground/80 hover:text-foreground px-4 py-2"
+          >
+            <Link href="/beacons/browse">
+              <ArrowLeft className="h-5 w-5" />
+              <span className="text-base">Return to Browse</span>
+            </Link>
+          </Button>
+
+          {/* Delete Button - only shown to beacon owner */}
+          {isOwner && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button 
+                  variant="destructive" 
+                  size="sm"
+                  className="flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white font-medium px-4 py-2 rounded"
+                  disabled={isDeleting}
+                >
+                  <Trash2 className="h-4 w-4" />
+                  <span>Delete Beacon</span>
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This action cannot be undone. This will permanently delete your beacon.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleDeleteBeacon}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    disabled={isDeleting}
+                  >
+                    {isDeleting ? 'Deleting...' : 'Delete'}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+        </div>
 
         {/* Title and Category */}
         <div className="flex items-center gap-3">

--- a/client/src/components/organisms/beacons/detailed-beacon.tsx
+++ b/client/src/components/organisms/beacons/detailed-beacon.tsx
@@ -60,7 +60,7 @@ const DetailedBeacon = ({ beacon, category }: DetailedBeaconProps) => {
         description: "Your beacon has been successfully deleted.",
         variant: "success",
       });
-      router.push("/beacons/browse");
+      router.push(`/profile/${userId}`);
     } catch (error) {
       console.error("Failed to delete beacon:", error);
       toast({

--- a/client/src/components/organisms/profile/profile-page.tsx
+++ b/client/src/components/organisms/profile/profile-page.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/atoms/alert-dialog";
 import { useDeleteUserMutation } from "@/redux/api";
 import { useRouter } from "next/navigation";
+import { useToast } from "@/components/atoms/use-toast";
 
 interface ProfilePageProps {
   profile: User;
@@ -59,16 +60,27 @@ export const ProfilePage: FC<ProfilePageProps> = ({
   const { signOut } = useAuth();
   const [deleteUser, { isLoading: isDeleting }] = useDeleteUserMutation();
   const router = useRouter();
+  const { toast } = useToast();
   
   const handleDeleteUser = async () => {
     try {
-      await deleteUser(profile.id);
+      await deleteUser(profile.id).unwrap();
+      toast({
+        title: "Account Deleted",
+        description: "Your account has been successfully deleted.",
+        variant: "success",
+      });
       // Sign out the user
       await signOut();
       // Redirect to home page
       router.push("/");
     } catch (error) {
       console.error("Error deleting user:", error);
+      toast({
+        title: "Deletion Failed",
+        description: "Failed to delete your account. Please try again.",
+        variant: "destructive",
+      });
     }
   };
 
@@ -160,21 +172,24 @@ export const ProfilePage: FC<ProfilePageProps> = ({
                           {isDeleting ? "Deleting..." : "Delete Account"}
                         </Button>
                       </AlertDialogTrigger>
-                      <AlertDialogContent>
+                      <AlertDialogContent className="bg-zinc-900 border-zinc-800 text-white">
                         <AlertDialogHeader>
-                          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-                          <AlertDialogDescription>
+                          <AlertDialogTitle className="text-white text-xl font-bold">Are you absolutely sure?</AlertDialogTitle>
+                          <AlertDialogDescription className="text-gray-300">
                             This action cannot be undone. This will permanently delete your
                             account and transfer all your beacons to a "Deleted User" account.
                           </AlertDialogDescription>
                         </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel className="transition-colors duration-200 hover:bg-gray-200 dark:hover:bg-gray-700">Cancel</AlertDialogCancel>
+                        <AlertDialogFooter className="flex gap-2 mt-6">
+                          <AlertDialogCancel className="bg-zinc-800 hover:bg-zinc-700 text-white border-none">
+                            Cancel
+                          </AlertDialogCancel>
                           <AlertDialogAction
                             onClick={handleDeleteUser}
-                            className="bg-red-600 text-white hover:bg-red-700 transition-colors duration-200"
+                            className="bg-red-600 hover:bg-red-700 text-white border-none"
+                            disabled={isDeleting}
                           >
-                            Delete Account
+                            {isDeleting ? 'Deleting...' : 'Delete Account'}
                           </AlertDialogAction>
                         </AlertDialogFooter>
                       </AlertDialogContent>


### PR DESCRIPTION
## Summary: 

- **Added beacon deletion capability for owners**  
- **Added safety checks before deleting beacons**  
- **Improved UI consistency** by matching the beacon deletion dialog with the profile deletion dialog style  
- **Properly handled image deletion** when removing beacons  
- **Standardized toast notifications and dialog styling** for account deletion  
- **Used ClerkService** for consistent token authentication  
- **Updated the destructive toast style to red**  
- **Added redirect to profile page** after beacon deletion  
